### PR TITLE
Drop change generic type `C` in FSM implementation

### DIFF
--- a/echo/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/internal/history/PersistentHistorySite.kt
+++ b/echo/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/internal/history/PersistentHistorySite.kt
@@ -126,7 +126,7 @@ internal class PersistentHistorySite<T, M, C>(
     val impl =
         object : EventScope<T> {
           override suspend fun yield(event: T) =
-              mutate(extract = { it.first }) { history: PersistentLogHistory<T, M, C> ->
+              mutate(extract = { it.first }) { history ->
                     history.forward(
                         HistoryEvent(
                             site = identifier,

--- a/echo/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/internal/history/PersistentHistorySite.kt
+++ b/echo/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/internal/history/PersistentHistorySite.kt
@@ -83,7 +83,7 @@ internal class PersistentHistorySite<T, M, C>(
    * @param O the type of the output messages.
    * @param S the type of the FSM states.
    */
-  private fun <I, O, S : State<I, O, T, C, S>> exchange(
+  private fun <I, O, S : State<I, O, T, S>> exchange(
       initial: suspend () -> S,
   ) =
       channelLink<I, O> { inc ->

--- a/echo/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/internal/history/StepScopeImpl.kt
+++ b/echo/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/internal/history/StepScopeImpl.kt
@@ -9,14 +9,14 @@ import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.selects.SelectClause1
 
 /** An implementation of [StepScope] that delegates behaviors. */
-internal class StepScopeImpl<I, O, T, C>(
+internal class StepScopeImpl<I, O, T>(
     inc: ReceiveChannel<I>,
     out: SendChannel<O>,
-    insertions: ReceiveChannel<ImmutableEventLog<T, C>>,
+    insertions: ReceiveChannel<ImmutableEventLog<T, *>>,
     private val update: suspend (SequenceNumber, SiteIdentifier, T) -> Unit,
-) : StepScope<I, O, T, C>, ReceiveChannel<I> by inc, SendChannel<O> by out {
+) : StepScope<I, O, T>, ReceiveChannel<I> by inc, SendChannel<O> by out {
 
-  override val onInsert: SelectClause1<ImmutableEventLog<T, C>> = insertions.onReceive
+  override val onInsert: SelectClause1<ImmutableEventLog<T, *>> = insertions.onReceive
 
   override suspend fun set(seqno: SequenceNumber, site: SiteIdentifier, event: T) {
     update(seqno, site, event)

--- a/echo/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/protocol/fsm/Step.kt
+++ b/echo/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/protocol/fsm/Step.kt
@@ -18,12 +18,11 @@ import kotlinx.coroutines.selects.SelectClause1
  *
  * @param I the type of the incoming messages.
  * @param O the type of the outgoing messages.
- * @param C the type of the changes.
  */
-internal interface StepScope<out I, in O, T, C> : ReceiveChannel<I>, SendChannel<O> {
+internal interface StepScope<out I, in O, T> : ReceiveChannel<I>, SendChannel<O> {
 
   /** A [SelectClause1] that's made available when a new value is inserted in the log. */
-  val onInsert: SelectClause1<ImmutableEventLog<T, C>>
+  val onInsert: SelectClause1<ImmutableEventLog<T, *>>
 
   /**
    * Sets the [event] for a certain [seqno] and a given [site]. This will mutate the current site,
@@ -33,10 +32,10 @@ internal interface StepScope<out I, in O, T, C> : ReceiveChannel<I>, SendChannel
 }
 
 /** A specific version of [StepScope] that receives [Inc] messages and sends [Out] messages. */
-internal typealias OutgoingStepScope<T, C> = StepScope<Inc<T>, Out<T>, T, C>
+internal typealias OutgoingStepScope<T> = StepScope<Inc<T>, Out<T>, T>
 
 /** A specific version of [StepScope] that receives [Out] messages and sends [Inc] messages. */
-internal typealias IncomingStepScope<T, C> = StepScope<Out<T>, Inc<T>, T, C>
+internal typealias IncomingStepScope<T> = StepScope<Out<T>, Inc<T>, T>
 
 /**
  * An [Effect] is a sealed class that is used to indicate what the next step of a finite state
@@ -75,10 +74,10 @@ internal sealed class Effect<out T> {
  * @param S the type of the [Effect] states.
  */
 // TODO : Make this a fun interface when b/KT-40165 is fixed.
-/* fun */ internal interface State<I, O, T, C, S : State<I, O, T, C, S>> {
+/* fun */ internal interface State<in I, out O, T, out S : State<I, O, T, S>> {
 
   /** Performs a suspending step of this FSM. */
-  suspend fun StepScope<I, O, T, C>.step(
-      log: ImmutableEventLog<T, C>,
+  suspend fun StepScope<I, O, T>.step(
+      log: ImmutableEventLog<T, *>,
   ): Effect<S>
 }


### PR DESCRIPTION
This change doesn't compile with the old Kotlin backend, and requires (at least) the following issue to be fixed :

- [KT-29075](https://youtrack.jetbrains.com/issue/KT-29075)

Migrating to IR or Kotlin 1.5.0 (when released) will likely fix the compilation issues with inline classes.