### PR TITLE
Remove nextForAll from Request message

### DIFF
--- a/echo-transport/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/serialization/Message.kt
+++ b/echo-transport/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/serialization/Message.kt
@@ -105,7 +105,6 @@ private class OutgoingSerializer<T> : JsonSerializer<Message.Outgoing<T>>() {
     private const val KeyType = "type"
     private const val KeySite = "site"
     private const val KeyNextForSite = "nextForSite"
-    private const val KeyNextForAll = "nextForAll"
     private const val KeyCount = "count"
 
     private const val TypeRequest = "request"
@@ -120,12 +119,10 @@ private class OutgoingSerializer<T> : JsonSerializer<Message.Outgoing<T>>() {
     return when (element.jsonObject[KeyType]?.jsonPrimitive?.contentOrNull) {
       TypeRequest -> {
         val site = element.jsonObject[KeySite] ?: badSerial()
-        val nextForAll = element.jsonObject[KeyNextForAll] ?: badSerial()
         val nextForSite = element.jsonObject[KeyNextForSite] ?: badSerial()
         val count = element.jsonObject[KeyCount] ?: badSerial()
         Message.Outgoing.Request(
             site = json.decodeFromJsonElement(SiteIdentifier.serializer(), site),
-            nextForAll = json.decodeFromJsonElement(SequenceNumber.serializer(), nextForAll),
             nextForSite = json.decodeFromJsonElement(SequenceNumber.serializer(), nextForSite),
             count = count.jsonPrimitive.longOrNull ?: badSerial())
       }
@@ -140,7 +137,6 @@ private class OutgoingSerializer<T> : JsonSerializer<Message.Outgoing<T>>() {
           encoder.encodeJsonElement(
               buildJsonObject {
                 put(KeyType, TypeRequest)
-                put(KeyNextForAll, value.nextForAll, json)
                 put(KeyNextForSite, value.nextForSite, json)
                 put(KeyCount, value.count)
                 put(KeySite, value.site, json)

--- a/echo-transport/src/commonTest/kotlin/io/github/alexandrepiveteau/echo/serialization/Fuzzing.kt
+++ b/echo-transport/src/commonTest/kotlin/io/github/alexandrepiveteau/echo/serialization/Fuzzing.kt
@@ -27,9 +27,7 @@ class Fuzzing {
       }
   private fun fuzzOutgoing() =
       when (Random.nextInt(until = 1)) {
-        0 ->
-            Outgoing.Request(
-                fuzzSequenceNumber(), fuzzSequenceNumber(), fuzzSiteIdentifier(), fuzzLong())
+        0 -> Outgoing.Request(fuzzSequenceNumber(), fuzzSiteIdentifier(), fuzzLong())
         else -> error("bad fuzzing")
       }
 

--- a/echo-transport/src/commonTest/kotlin/io/github/alexandrepiveteau/echo/serialization/OutgoingTest.kt
+++ b/echo-transport/src/commonTest/kotlin/io/github/alexandrepiveteau/echo/serialization/OutgoingTest.kt
@@ -15,7 +15,6 @@ class OutgoingTest {
         """
             { "type": "request"
             , "nextForSite": 123
-            , "nextForAll": 321
             , "site": "00000000"
             , "count": 42
             }
@@ -24,7 +23,6 @@ class OutgoingTest {
     assertEquals(
         Outgoing.Request(
             nextForSite = SequenceNumber(123u),
-            nextForAll = SequenceNumber(321u),
             site = SiteIdentifier(Int.MIN_VALUE),
             count = 42,
         ),

--- a/echo/api/echo.api
+++ b/echo/api/echo.api
@@ -285,17 +285,15 @@ public final class io/github/alexandrepiveteau/echo/protocol/Message$Outgoing$Co
 }
 
 public final class io/github/alexandrepiveteau/echo/protocol/Message$Outgoing$Request : io/github/alexandrepiveteau/echo/protocol/Message$Outgoing {
-	public synthetic fun <init> (IIIJILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (IIIJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (IIJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (IIJLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-o38t-jg ()I
-	public final fun component2-o38t-jg ()I
-	public final fun component3--e_yCgk ()I
-	public final fun component4 ()J
-	public final fun copy-v_Wa35U (IIIJ)Lio/github/alexandrepiveteau/echo/protocol/Message$Outgoing$Request;
-	public static synthetic fun copy-v_Wa35U$default (Lio/github/alexandrepiveteau/echo/protocol/Message$Outgoing$Request;IIIJILjava/lang/Object;)Lio/github/alexandrepiveteau/echo/protocol/Message$Outgoing$Request;
+	public final fun component2--e_yCgk ()I
+	public final fun component3 ()J
+	public final fun copy-F9woSY0 (IIJ)Lio/github/alexandrepiveteau/echo/protocol/Message$Outgoing$Request;
+	public static synthetic fun copy-F9woSY0$default (Lio/github/alexandrepiveteau/echo/protocol/Message$Outgoing$Request;IIJILjava/lang/Object;)Lio/github/alexandrepiveteau/echo/protocol/Message$Outgoing$Request;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCount ()J
-	public final fun getNextForAll-o38t-jg ()I
 	public final fun getNextForSite-o38t-jg ()I
 	public final fun getSite--e_yCgk ()I
 	public fun hashCode ()I

--- a/echo/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/protocol/Message.kt
+++ b/echo/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/protocol/Message.kt
@@ -118,16 +118,12 @@ sealed class Message<out T> {
      * - The request is tied to a specific [site]. You may not issue a [Request] for a
      * [SiteIdentifier] that has not been advertised through an [Incoming.Advertisement].
      * - The [nextForSite] indicates what the requested sequence number for the specific [site] is.
-     * - The [nextForAll] indicates the requested sequence number if the other site was to generate
-     * an event that's definitely higher than your current knowledge.
      *
-     * @param nextForAll the next [SequenceNumber] that is expected for all the sites.
      * @param nextForSite the next [SequenceNumber] that is expected for the [site].
      * @param site the site identifier for which we're interested in this sequence number.
      * @param count how many events were requested.
      */
     data class Request(
-        val nextForAll: SequenceNumber,
         val nextForSite: SequenceNumber,
         val site: SiteIdentifier,
         val count: Long = Long.MAX_VALUE,

--- a/echo/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/protocol/fsm/OutgoingState.kt
+++ b/echo/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/protocol/fsm/OutgoingState.kt
@@ -77,13 +77,11 @@ private data class OutgoingListening<T, C>(
   ): Effect<OutgoingState<T, C>> {
     val request = pendingRequests.lastOrNull()
     val expected = request?.let(log::expected) ?: SequenceNumber.Zero
-    val max = log.expected
 
     return select {
       if (request != null) {
         onSend(
             Out.Request(
-                nextForAll = max,
                 nextForSite = expected,
                 site = request,
                 count = Long.MAX_VALUE,

--- a/echo/src/commonTest/kotlin/io/github/alexandrepiveteau/echo/memory/MemoryExchangeIncomingTest.kt
+++ b/echo/src/commonTest/kotlin/io/github/alexandrepiveteau/echo/memory/MemoryExchangeIncomingTest.kt
@@ -106,7 +106,7 @@ class MemoryExchangeIncomingTest {
         channelLink<I<Boolean>, O<Boolean>> { incoming ->
               assertEquals(I.Advertisement(site), incoming.receive())
               assertEquals(I.Ready, incoming.receive())
-              send(O.Request(seqno, seqno, site = site))
+              send(O.Request(seqno, site = site))
               assertEquals(I.Event(seqno, site, true), incoming.receive())
               close()
               assertNull(incoming.receiveOrNull())
@@ -125,7 +125,7 @@ class MemoryExchangeIncomingTest {
         channelLink<I<Boolean>, O<Boolean>> { incoming ->
           assertEquals(I.Advertisement(site), incoming.receive())
           assertEquals(I.Ready, incoming.receive())
-          send(O.Request(seqno, seqno, site, count = 0))
+          send(O.Request(seqno, site, count = 0))
           incoming.receive()
           fail("incoming.receive() should have timeout.")
         }
@@ -143,8 +143,8 @@ class MemoryExchangeIncomingTest {
         channelLink<I<Boolean>, O<Boolean>> { incoming ->
           assertEquals(I.Advertisement(site), incoming.receive())
           assertEquals(I.Ready, incoming.receive())
-          send(O.Request(seqno, seqno, site, count = 0))
-          send(O.Request(seqno, seqno, site, count = 1))
+          send(O.Request(seqno, site, count = 0))
+          send(O.Request(seqno, site, count = 1))
           assertEquals(I.Event(seqno, site, true), incoming.receive())
           close()
           assertNull(incoming.receiveOrNull())


### PR DESCRIPTION
+ Added an additional unit test to check distributed `yield` calls respect causality.