### PR TITLE
Make Protobuf serialization more compact

### DIFF
--- a/echo-core/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/core/causality/EventIdentifier.serialization.kt
+++ b/echo-core/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/core/causality/EventIdentifier.serialization.kt
@@ -7,7 +7,6 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
-// TODO : Use a human-readable representation ?
 internal object EventIdentifierSerializer : KSerializer<EventIdentifier> {
 
   override val descriptor: SerialDescriptor =

--- a/echo-core/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/core/causality/SequenceNumber.serialization.kt
+++ b/echo-core/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/core/causality/SequenceNumber.serialization.kt
@@ -1,34 +1,24 @@
 package io.github.alexandrepiveteau.echo.core.causality
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.SerializationException
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
-/**
- * [SequenceNumber] are represented as a [Long] in their serialized format, even though only the
- * least significant 32 bits are actually used.
- */
 internal object SequenceNumberSerializer : KSerializer<SequenceNumber> {
 
   override val descriptor: SerialDescriptor =
-      PrimitiveSerialDescriptor("SequenceNumber", PrimitiveKind.LONG)
+      PrimitiveSerialDescriptor("SequenceNumber", PrimitiveKind.INT)
 
   override fun deserialize(decoder: Decoder): SequenceNumber {
-    val decoded = decoder.decodeLong()
-    val leastSignificant = decoded and 0xFFFFFFFF
-    if (decoded != leastSignificant)
-        throw SerializationException(
-            "SequenceNumber not in [${UInt.MIN_VALUE}, ${UInt.MAX_VALUE}] range",
-        )
-    return leastSignificant.toUInt().toSequenceNumber()
+    val decoded = decoder.decodeInt().toUInt()
+    return SequenceNumber(index = decoded)
   }
 
   override fun serialize(encoder: Encoder, value: SequenceNumber) {
-    val encoded = value.toUInt().toLong()
-    encoder.encodeLong(encoded)
+    val encoded = value.index.toInt()
+    encoder.encodeInt(encoded)
   }
 }

--- a/echo-core/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/core/causality/SiteIdentifier.serialization.kt
+++ b/echo-core/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/core/causality/SiteIdentifier.serialization.kt
@@ -1,40 +1,24 @@
 package io.github.alexandrepiveteau.echo.core.causality
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.SerializationException
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
-/**
- * [SiteIdentifier] are represented as a [String] in their serialized format, with exactly 8
- * characters. Each character is in the hexadecimal range [0, F].
- */
 internal object SiteIdentifierSerializer : KSerializer<SiteIdentifier> {
 
-  // How much values are shifted in their encoding / representation.
-  private const val HALF_INT = 1 shl 31
-
-  // Format.
-  private const val RADIX = 16
-  private const val LENGTH = 8
-
   override val descriptor: SerialDescriptor =
-      PrimitiveSerialDescriptor("SiteIdentifier", PrimitiveKind.STRING)
+      PrimitiveSerialDescriptor("SiteIdentifier", PrimitiveKind.INT)
 
   override fun deserialize(decoder: Decoder): SiteIdentifier {
-    val packed = decoder.decodeString()
-    val unpacked =
-        packed.toUIntOrNull(RADIX) ?: throw SerializationException("Invalid SiteIdentifier")
-    val unshifted = unpacked + HALF_INT.toUInt()
-    return unshifted.toSiteIdentifier()
+    val decoded = decoder.decodeInt().toUInt()
+    return SiteIdentifier(unique = decoded)
   }
 
   override fun serialize(encoder: Encoder, value: SiteIdentifier) {
-    val shifted = value.toUInt() + HALF_INT.toUInt()
-    val packed = shifted.toString(RADIX).padStart(LENGTH, '0')
-    encoder.encodeString(packed)
+    val encoded = value.unique.toInt()
+    encoder.encodeInt(encoded)
   }
 }

--- a/echo/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/protocol/Message.kt
+++ b/echo/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/protocol/Message.kt
@@ -4,6 +4,7 @@ import io.github.alexandrepiveteau.echo.core.causality.SequenceNumber
 import io.github.alexandrepiveteau.echo.core.causality.SiteIdentifier
 import io.github.alexandrepiveteau.echo.protocol.Message.Incoming
 import io.github.alexandrepiveteau.echo.protocol.Message.Outgoing
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
@@ -74,6 +75,7 @@ sealed class Message {
      * @param nextSeqno the next expected [SequenceNumber] for the available site.
      */
     @Serializable
+    @SerialName("adv")
     data class Advertisement(
         val site: SiteIdentifier,
         val nextSeqno: SequenceNumber,
@@ -88,7 +90,7 @@ sealed class Message {
      * When you're interested in one-off syncs, this is usually a good place to start ignoring new
      * [Advertisement] messages.
      */
-    @Serializable object Ready : Incoming()
+    @SerialName("rdy") @Serializable object Ready : Incoming()
 
     /**
      * Sends an event, alongside its body, to the [Outgoing] side. When sending an event, you
@@ -100,6 +102,7 @@ sealed class Message {
      * @param body the domain-specific body of the [Event].
      */
     @Serializable
+    @SerialName("e")
     data class Event(
         val seqno: SequenceNumber,
         val site: SiteIdentifier,
@@ -142,6 +145,7 @@ sealed class Message {
      * @param nextSeqno the next expected sequence number for this site.
      */
     @Serializable
+    @SerialName("ack")
     data class Acknowledge(
         val site: SiteIdentifier,
         val nextSeqno: SequenceNumber,
@@ -160,6 +164,7 @@ sealed class Message {
      * @param count how many events were requested.
      */
     @Serializable
+    @SerialName("req")
     data class Request(
         val site: SiteIdentifier,
         val count: UInt,


### PR DESCRIPTION
This PR adds custom class discriminators, and uses a more compact and slightly faster binary serialisation scheme for `SiteIdentifier`, `EventIdentifier` and `SequenceNumber`.